### PR TITLE
Import button on available snippet views

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This package will attempt to match a model object against row in Airtable using 
 ### Installation & Configuration
 
 * Install the package with `pip install wagtail-airtable`
-* Add `'wagtail_airtable'` to your project's `INSTALLED_APPS`
+* Add `'wagtail_airtable'` to your project's `INSTALLED_APPS`.
+    * To enable the snippet-specific import button on the Snippet list view, you'll want to make sure `wagtail_airtable` is above `wagtail.snippets` in your `INSTALLED_APPS`
 * In your settings you will need to map models to Airtable settings. Every model you want to map to an Airtable sheet will need:
     * An `AIRTABLE_BASE_KEY`. You can find the base key in your Airtable docs when you're signed in to Airtable.com
     * An `AIRTABLE_TABLE_NAME` to determine which table to connect to.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This package will attempt to match a model object against row in Airtable using 
 
 * Install the package with `pip install wagtail-airtable`
 * Add `'wagtail_airtable'` to your project's `INSTALLED_APPS`.
-    * To enable the snippet-specific import button on the Snippet list view, you'll want to make sure `wagtail_airtable` is above `wagtail.snippets` in your `INSTALLED_APPS`
-* In your settings you will need to map models to Airtable settings. Every model you want to map to an Airtable sheet will need:
-    * An `AIRTABLE_BASE_KEY`. You can find the base key in your Airtable docs when you're signed in to Airtable.com
+    * To enable the snippet-specific import button on the Snippet list view make sure `wagtail_airtable` is above `wagtail.snippets` in your `INSTALLED_APPS`
+* In your settings you will need to map Django models to Airtable settings. Every model you want to map to an Airtable sheet will need:
+    * An `AIRTABLE_BASE_KEY`. You can find the base key in the [https://airtable.com/api](Airtable API docs) when you're signed in to Airtable.com
     * An `AIRTABLE_TABLE_NAME` to determine which table to connect to.
     * An `AIRTABLE_UNIQUE_IDENTIFIER`. This can either be a string or a dictionary mapping the Airtable column name to your unique field in your model.
         * ie. `AIRTABLE_UNIQUE_IDENTIFIER: 'slug',` this will match the `slug` field on your model with the `slug` column name in Airtable. Use this option if your model field and your Airtable column name are identical.

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+
+from wagtail_airtable.templatetags.wagtail_airtable_tags import can_import_model
+
+
+class TestTemplateTags(TestCase):
+
+    def test_can_import_model(self):
+        allowed_to_import = can_import_model("tests.Advert")
+        self.assertTrue(allowed_to_import)
+
+    def test_cannot_import_model(self):
+        allowed_to_import = can_import_model("tests.MissingModel")
+        self.assertFalse(allowed_to_import)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -25,3 +25,11 @@ class TestAdminViews(TestCase):
         instance = response.context_data['instance']
         self.assertEqual(instance.airtable_record_id, '')
 
+    def test_import_snippet_button_on_list_view(self):
+        response = self.client.get('/admin/snippets/tests/advert/')
+        self.assertContains(response, 'Import Advert')
+
+    def test_no_import_snippet_button_on_list_view(self):
+        response = self.client.get('/admin/snippets/tests/modelnotused/')
+        self.assertNotContains(response, 'Import Advert')
+

--- a/wagtail_airtable/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail_airtable/templates/wagtailsnippets/snippets/type_index.html
@@ -1,0 +1,51 @@
+{% extends "wagtailsnippets/snippets/type_index.html" %}
+{% load i18n wagtailadmin_tags wagtail_airtable_tags %}
+
+
+{% block content %}
+    {% can_import_model model_opts.label as can_import_model %}
+    <header class="nice-padding">
+        <div class="row row-flush">
+            <div class="left col6 header-title">
+                <h1 class="icon icon-snippet">
+                {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
+
+                {% if is_searchable %}
+                    <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get" novalidate>
+                        <ul class="fields">
+                            {% for field in search_form %}
+                                {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}
+                            {% endfor %}
+                            <li class="submit visuallyhidden"><input type="submit" value="Search" class="button" /></li>
+                        </ul>
+                    </form>
+                {% endif %}
+            </div>
+            <div class="right col6">
+                {% if can_delete_snippets %}
+                    <a class="button bicolor icon icon-bin serious delete-button visuallyhidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}</a>
+                {% endif %}
+                {% if can_add_snippet %}
+                    <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor icon icon-plus">{% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
+                    {# TODO: figure out a way of saying "Add a/an [foo]" #}
+                    {% if can_import_model %}
+                      <form action="{% url 'airtable_import_listing' %}" method="post" style='display: inline-block;'>
+                        {% csrf_token %}
+                        <input type="hidden" name="model" value="{{ model_opts.label }}" />
+                        <button type="submit" class="button bicolor icon icon-plus button-longrunning" data-clicked-text="Importing...">
+                          <span class="icon icon-spinner"></span>
+                          <em>{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Import {{ snippet_type_name }}{% endblocktrans %}</em>
+                        </button>
+                      </form>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </div>
+    </header>
+
+    <div class="nice-padding">
+        <div id="snippet-results" class="snippets">
+            {% include "wagtailsnippets/snippets/results.html" %}
+        </div>
+    </div>
+{% endblock %}

--- a/wagtail_airtable/templatetags/wagtail_airtable_tags.py
+++ b/wagtail_airtable/templatetags/wagtail_airtable_tags.py
@@ -1,0 +1,20 @@
+from django import template
+from django.conf import settings
+
+
+register = template.Library()
+
+@register.simple_tag
+def can_import_model(model_path) -> bool:
+    """
+    Check if a model can be imported based on it's model label.
+
+    Use:
+    {% load wagtail_airtable_tags %}
+    {% can_import_model "yourapp.ModelName" as template_var %}
+
+    Returns True or False.
+    """
+    airtable_settings = getattr(settings, "AIRTABLE_IMPORT_SETTINGS", {})
+    has_settings = airtable_settings.get(model_path, False)
+    return bool(has_settings)

--- a/wagtail_airtable/templatetags/wagtail_airtable_tags.py
+++ b/wagtail_airtable/templatetags/wagtail_airtable_tags.py
@@ -5,9 +5,9 @@ from django.conf import settings
 register = template.Library()
 
 @register.simple_tag
-def can_import_model(model_path) -> bool:
+def can_import_model(model_label) -> bool:
     """
-    Check if a model can be imported based on it's model label.
+    Check if a model can be imported based on its model label.
 
     Use:
     {% load wagtail_airtable_tags %}
@@ -16,5 +16,5 @@ def can_import_model(model_path) -> bool:
     Returns True or False.
     """
     airtable_settings = getattr(settings, "AIRTABLE_IMPORT_SETTINGS", {})
-    has_settings = airtable_settings.get(model_path, False)
+    has_settings = airtable_settings.get(model_label, False)
     return bool(has_settings)


### PR DESCRIPTION
Provides an import button for the snippet list view. 

Included is a template tag (with tests) to determine if a model is setup in the settings. No additional validation added at this point, however. 

![image](https://user-images.githubusercontent.com/4743971/83057449-247a3400-a014-11ea-8ea5-69cde1720630.png)
