### PR TITLE
Add a _skip_signals flag before saving models

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ By default the `import_airtable` command adds an additional attribute to the mod
 ```
 @receiver(post_save, sender=MyModel)
 def post_save_function(sender, **kwargs):
-    if not sender._skip_signals:
+    if not hasattr(sender, "_skip_signals"):
         # rest of logic
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ Optionally you can turn up the verbosity for better debugging with the `--verbos
 ##### import_airtable command
 This command will look for any `appname.ModelName`s you provide it and use the mapping settings to find data in the Airtable. See the "Behind the scenes" section for more details on how importing works.
 
+##### skipping django signals
+By default the `import_airtable` command adds an additional attribute to the models being saved called `_skip_signals` - which is set to `True` you can use this to bypass any `post_save` or `pre_save` signals you might have on the models being imported so those don't run. e.g.
+
+```
+@receiver(post_save, sender=MyModel)
+def post_save_function(sender, **kwargs):
+    if not sender._skip_signals:
+        # rest of logic
+```
+
+if you don't do these checks on your signal, the save will run normally. 
+
 ### Local Testing Advice
 
 > **Note:** Be careful not to use the production settings as you could overwrite Wagtail or Airtable data.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ By default the `import_airtable` command adds an additional attribute to the mod
 ```
 @receiver(post_save, sender=MyModel)
 def post_save_function(sender, **kwargs):
-    if not hasattr(sender, "_skip_signals"):
+    if sender._skip_signals:
         # rest of logic
 ```
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -203,6 +203,8 @@ class TestImportClass(TestCase):
         saved = importer.update_object(instance, 'recNewRecordId', serialized_data)
 
         self.assertTrue(saved)
+        # Check to make sure _skip_signals is set.
+        self.assertTrue(instance._skip_signals)
         self.assertEqual(importer.updated, 1)
         self.assertEqual(importer.records_used, ['recNewRecordId'])
         # Re-fetch the Advert instance and check its airtable_record_id

--- a/wagtail_airtable/management/commands/import_airtable.py
+++ b/wagtail_airtable/management/commands/import_airtable.py
@@ -155,6 +155,7 @@ class Importer:
                             "\t\t\t Page is not locked. Saving page and creating a new revision."
                         )
                         # Only save the page if the page is not locked
+                        instance._skip_signals=True
                         instance.save()
                         instance.save_revision()
                         self.updated = self.updated + 1
@@ -164,6 +165,7 @@ class Importer:
                 else:
                     # Django model. Save normally.
                     self.debug_message("\t\t Saving Django model")
+                    instance._skip_signals=True
                     instance.save()
                     self.updated = self.updated + 1
 
@@ -252,6 +254,7 @@ class Importer:
                             # Wagtail page. Requires a .save_revision()
                             if not instance.locked:
                                 # Only save the page if the page is not locked
+                                instance._skip_signals=True
                                 instance.save()
                                 instance.save_revision()
                                 self.updated = self.updated + 1
@@ -262,6 +265,7 @@ class Importer:
                                 self.skipped = self.skipped + 1
                         else:
                             # Django model. Save normally.
+                            instance._skip_signals=True
                             instance.save()
                             self.debug_message("\t\t\t Saved!")
                             self.updated = self.updated + 1
@@ -483,6 +487,7 @@ class Importer:
                 try:
                     self.debug_message("\t\t Attempting to create a new object...")
                     new_model = model(**data_for_new_model)
+                    new_model._skip_signals=True
                     new_model.save()
                     self.debug_message("\t\t Object created")
                     self.created = self.created + 1

--- a/wagtail_airtable/mixins.py
+++ b/wagtail_airtable/mixins.py
@@ -24,6 +24,9 @@ class AirtableMixin(models.Model):
     AIRTABLE_TABLE_NAME = None
     AIRTABLE_UNIQUE_IDENTIFIER = None
 
+    # On import, a lot of saving happens, so this attribute gets set to True during import and could be
+    # used as a bit of logic to skip a post_save signal, for example.
+    _skip_signals = False
     # If the Airtable integration for this model is enabled. Used for sending data to Airtable.
     _is_enabled = False
     # If the Airtable api setup is complete in this model. Used for singleton-like setup_airtable() method.


### PR DESCRIPTION
# What this does
- Adds `_skip_signals=True` to the model or model instance before saving. 

# Why?
If a user has a `post_save` signal setup and doesn't want it called on the model during import, this additional attribute can help aid in that. So the post_save function definition could contain something like:
```
if not instance._skip_signals:
    <do the function>
```
Which would ensure that every call to save isn't also calling the `post_save` signal.

If they don't do that, the import works normally. 