### PR TITLE
Add catch for MultipleObjectsReturned

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,10 @@ Clone the project and cd into the `wagtail-airtable/tests/` directory. Then run 
 To target a specific test you can run `python runtests.py tests.test_file.TheTestClass.test_specific_model`
 
 Tests are written against Wagtail 2.10 and later.
+
+
+### Trouble Shooting Tips
+#### Duplicates happening on import
+Ensure that your serializer matches your field definition *exactly*, and in cases of `CharField`'s that have `blank=True` or `null=True` setting `required=False` on the serializer is also important. 
+
+In some cases 2 Models may get the same Airtable ID. To circumvent this error on imports the first one found will be set as the "real" one and the "impostors" will be set to `""` - this may create duplicate models in your system, if this is happening a lot. Make sure your export method and serializer import are set correctly. 

--- a/wagtail_airtable/management/commands/import_airtable.py
+++ b/wagtail_airtable/management/commands/import_airtable.py
@@ -442,7 +442,8 @@ class Importer:
                     obj = objs[0]
                     for ob in objs[1:]:
                         # set airtable_record_id on the "impostors" to ""
-                        ob.update(airtable_record_id="")
+                        ob.airtable_record_id = ""
+                        ob.save()
 
 
                 if obj:

--- a/wagtail_airtable/management/commands/import_airtable.py
+++ b/wagtail_airtable/management/commands/import_airtable.py
@@ -435,6 +435,15 @@ class Importer:
                 except model.DoesNotExist:
                     obj = None
                     self.debug_message("\t\t Local object was NOT found")
+                except model.MultipleObjectsReturned:
+                    # In the case that multiple models have gotten the same record_id
+                    objs = model.objects.filter(airtable_record_id=record_id)
+                    # Set the first one to be the "right" one
+                    obj = objs[0]
+                    for ob in objs[1:]:
+                        # set airtable_record_id on the "impostors" to ""
+                        ob.update(airtable_record_id="")
+
 
                 if obj:
                     # Model object was found by it's airtable_record_id


### PR DESCRIPTION
# What this does
- Adds catch for `MultipleObjectsReturned`
- Assigns the first one as the "real" one
- Sets the `airtable_record_id` to `""` for the 'other' records that were returned.
