### PR TITLE
add a handler for 502 errors

### DIFF
--- a/wagtail_airtable/mixins.py
+++ b/wagtail_airtable/mixins.py
@@ -279,6 +279,12 @@ class AirtableMixin(models.Model):
             }
 
         code = int(error.split(":", 1)[0].split(" ")[0])
+        if code == 502:
+            return {
+                "status_code": code,
+                "type": "SERVER_ERROR",
+                "message": "Service may be down, or is otherwise uncreachable"
+            }        
         error_json = error.split("[Error: ")[1].rstrip("]")
         if error_json == "NOT_FOUND":  # 404's act different
             return {


### PR DESCRIPTION
# What this does
We had an error report from sentry recently giving a `IndexError: list index out of range` because of how the split is handled in the parse_request_error method. This adds an additional check to see if the code is a 502, and responds similarly to how the 503 is handled. 

The 502 error message looked like this:
```

'502 Server Error: Bad Gateway for url: https://api.airtable.com/...'

```
URL specifics removed for privacy. 