### PR TITLE
Replace deprecated function django.conf.urls.url

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtail_urls)),
+    path("admin/", include(wagtailadmin_urls)),
+    path("", include(wagtail_urls)),
 ]

--- a/wagtail_airtable/wagtail_hooks.py
+++ b/wagtail_airtable/wagtail_hooks.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
-from django.urls import reverse
+from django.urls import path, reverse
 from wagtail.core import hooks
 from wagtail.admin.menu import MenuItem
 
@@ -12,8 +11,8 @@ from .mixins import AirtableMixin
 @hooks.register("register_admin_urls")
 def register_airtable_url():
     return [
-        url(
-            r"^airtable-import/$",
+        path(
+            "airtable-import/",
             AirtableImportListing.as_view(),
             name="airtable_import_listing",
         ),


### PR DESCRIPTION
`django.conf.urls.url` is [deprecated in Django 3.1](https://docs.djangoproject.com/en/4.0/releases/3.1/#features-deprecated-in-3-1) and [removed in Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0).

It doesn't look like there's any complicated URLs, so I use `django.urls.path` instead of `django.urls.re_path` as the replacement. ([django.urls functions](https://docs.djangoproject.com/en/dev/ref/urls/))